### PR TITLE
Fixed bug when using primary_key config

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -58,7 +58,6 @@ class QueryBuilder
     $this->store = $store;
     $this->useCache = $store->_getUseCache();
     $this->cacheLifetime = $store->_getDefaultCacheLifetime();
-    $this->orderBy["field"] = $store->getPrimaryKey();
   }
 
   /**


### PR DESCRIPTION
orderBy properties `field` doesn't have to be set automatically because the execution method has a new algorithm.