### PR TITLE
Improved search algorithm + new search method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a652b135c6e181907818e3f98938a0dd",
+    "content-hash": "a5544b7c61330a471d50e05a70e66d50",
     "packages": [],
     "packages-dev": [
         {
@@ -2594,12 +2594,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -2637,8 +2637,8 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
             },
             "time": "2020-07-08T17:02:28+00:00"
         },
@@ -2707,7 +2707,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mbstring": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/src/Query.php
+++ b/src/Query.php
@@ -554,16 +554,12 @@ class Query
 
     // apply additional changes to result like sort and limit
 
-    if (count($found) > 0) {
-      // If there was text search then we would also sort the result by search ranking.
-      $searchKeyword = $this->getQueryBuilderProperty("searchKeyword");
-      if (!empty($searchKeyword)) {
-        $found = $this->performSearch($found);
-      }
-    }
-
     if($reduceResultAndJoinPossible === true){
       $this->joinData($found);
+    }
+
+    if (count($found) > 0) {
+      $found = $this->performSearch($found);
     }
 
     if(count($found) > 0){
@@ -1161,52 +1157,94 @@ class Query
   private function performSearch(array $data = []): array
   {
 
-    // TODO apply custom key -> search rank, so the user can use that in order by!
-
-    $searchKeyword = $this->getQueryBuilderProperty("searchKeyword");
-    if (empty($data)) {
+    $search = $this->getQueryBuilderProperty("search");
+    if(empty($search)){
       return $data;
     }
-    $nodesRank = [];
-    // Looping on each store data.
-    foreach ($data as $key => $value) {
-      // Looping on each field name of search-able fields.
-      if(!is_array($searchKeyword)) {
-        break;
+
+    $searchOptions = $this->getQueryBuilderProperty("searchOptions");
+    $minLength = $searchOptions["minLength"];
+    $searchScoreKey = $searchOptions["scoreKey"];
+    $searchMode = $searchOptions["mode"];
+
+    $scoreMultiplier = 64;
+    $encoding = "UTF-8";
+
+    $fields = $search["fields"];
+    $query = $search["query"];
+    $lowerQuery = mb_strtolower($query, $encoding);
+    $exactQuery  = preg_quote($query, null);
+
+    $highestScore = $scoreMultiplier ** count($fields);
+
+    // split query
+    $searchWords = preg_replace('/(\s)/u', ',', $query);
+    $searchWords = explode(",", $searchWords);
+
+    // apply min word length
+    $temp = [];
+    foreach ($searchWords as $searchWord){
+      if(strlen($searchWord) >= $minLength){
+        $temp[] = $searchWord;
       }
-      foreach ($searchKeyword['field'] as $field) {
-        try {
-          $nodeValue = $this->getNestedProperty($field, $value);
-          // The searchable field was found, do comparison against search keyword.
-          $percent = 0;
-          if(is_string($nodeValue)){
-            similar_text(strtolower($nodeValue), strtolower($searchKeyword['keyword']), $percent);
-          }
-          if ($percent > 50) {
-            // Check if current store object already has a value, if so then add the new value.
-            if (isset($nodesRank[$key])) {
-              $nodesRank[$key] += $percent;
-            } else {
-              $nodesRank[$key] = $percent;
-            }
-          }
-        } catch (Exception $e) {
+    }
+    $searchWords = $temp;
+    unset($temp);
+    $searchWords = array_map(function($value){
+      return preg_quote($value, null);
+    }, $searchWords);
+
+    if($searchMode === "and"){
+      $preg = '!(' . implode('.*', $searchWords) . ')!i';
+    } else {
+      $preg = '!(' . implode('|', $searchWords) . ')!i';
+    }
+
+    $result = [];
+    foreach ($data as $document) {
+      $searchHits = 0;
+      $searchScore = 0;
+      foreach ($fields as $key => $field) {
+        $score = $highestScore / ($scoreMultiplier ** $key);
+        $value = $this->getNestedProperty($field, $document);
+        if ($value === null) {
           continue;
         }
+
+        $lowerValue = (is_string($value)) ? mb_strtolower($value, $encoding) : $value;
+
+        if ($lowerQuery == $lowerValue) {
+          // exact match
+          $searchHits++;
+          $searchScore += 16 * $score;
+        } elseif (mb_strpos($lowerValue, $lowerQuery, 0, $encoding) === 0) {
+          // exact beginning match
+          $searchHits++;
+          $searchScore += 8 * $score;
+        } elseif ($matches = preg_match_all('!' . $exactQuery . '!i', $value)) {
+          // exact query match
+          $searchHits += $matches;
+          $searchScore += 2 * $score;
+        }
+
+        if ($matches = preg_match_all($preg, $value)) {
+          // any match
+          $searchHits += $matches;
+          $searchScore += $matches * $score;
+        }
+      }
+
+      if($searchHits > 0){
+        if(!is_null($searchScoreKey)){
+          $document["searchHits"] = $searchHits;
+          $document[$searchScoreKey] = $searchScore;
+        }
+        $result[] = $document;
       }
     }
-    if (empty($nodesRank)) {
-      // No matched store was found against the search keyword.
-      return [];
-    }
-    // Sort nodes in descending order by the rank.
-    arsort($nodesRank);
-    // Map original nodes by the rank.
-    $nodes = [];
-    foreach ($nodesRank as $key => $value) {
-      $nodes[] = $data[$key];
-    }
-    return $nodes;
+
+    return $result;
+
   }
 
   /**

--- a/src/Query.php
+++ b/src/Query.php
@@ -1153,6 +1153,7 @@ class Query
    * @param array $data
    * @return array
    * @throws InvalidPropertyAccessException
+   * @throws InvalidArgumentException
    */
   private function performSearch(array $data = []): array
   {
@@ -1173,7 +1174,7 @@ class Query
     $fields = $search["fields"];
     $query = $search["query"];
     $lowerQuery = mb_strtolower($query, $encoding);
-    $exactQuery  = preg_quote($query, null);
+    $exactQuery  = preg_quote($query, "/");
 
     $highestScore = $scoreMultiplier ** count($fields);
 
@@ -1191,15 +1192,17 @@ class Query
     $searchWords = $temp;
     unset($temp);
     $searchWords = array_map(function($value){
-      return preg_quote($value, null);
+      return preg_quote($value, "/");
     }, $searchWords);
 
+    // apply mode
     if($searchMode === "and"){
       $preg = '!(' . implode('.*', $searchWords) . ')!i';
     } else {
       $preg = '!(' . implode('|', $searchWords) . ')!i';
     }
 
+    // search
     $result = [];
     foreach ($data as $document) {
       $searchHits = 0;
@@ -1236,7 +1239,6 @@ class Query
 
       if($searchHits > 0){
         if(!is_null($searchScoreKey)){
-          $document["searchHits"] = $searchHits;
           $document[$searchScoreKey] = $searchScore;
         }
         $result[] = $document;

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -279,7 +279,7 @@ class QueryBuilder
   }
 
   /**
-   * Do a fulltext like search against more than one field.
+   * Do a fulltext like search against one or multiple fields.
    * @param string|array $fields one or multiple fieldNames as an array
    * @param string $query
    * @param array $options
@@ -288,12 +288,25 @@ class QueryBuilder
    */
   public function search($fields, string $query, array $options = []): QueryBuilder
   {
+    if(!is_array($fields) && !is_string($fields)){
+      throw new InvalidArgumentException("Fields to search through have to be either a string or an array.");
+    }
+
+    if(!is_array($fields)){
+      $fields = (array)$fields;
+    }
+
     if (empty($fields)) {
       throw new InvalidArgumentException('Cant perform search due to no field name was provided');
     }
+
+    if(count($fields) > 100){
+      throw new InvalidArgumentException('Searching through more than 100 fields is not supported.');
+    }
+
     if (!empty($query)) {
       $this->search = [
-        'fields' => (array)$fields,
+        'fields' => $fields,
         'query' => $query
       ];
       if(!empty($options)){

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -22,7 +22,12 @@ class QueryBuilder
   protected $limit = 0;
   protected $orderBy = [];
   protected $nestedWhere = []; // TODO remove with version 3.0
-  protected $searchKeyword = "";
+  protected $search = [];
+  protected $searchOptions = [
+    "minLength" => 2,
+    "scoreKey" => "searchScore",
+    "mode" => "or"
+  ];
 
   protected $fieldsToSelect = [];
   protected $fieldsToExclude = [];
@@ -59,6 +64,7 @@ class QueryBuilder
     $this->store = $store;
     $this->useCache = $store->_getUseCache();
     $this->cacheLifetime = $store->_getDefaultCacheLifetime();
+    $this->searchOptions = $store->_getSearchOptions();
   }
 
   /**
@@ -274,21 +280,36 @@ class QueryBuilder
 
   /**
    * Do a fulltext like search against more than one field.
-   * @param string|array $field one fieldName or multiple fieldNames as an array
-   * @param string $keyword
+   * @param string|array $fields one or multiple fieldNames as an array
+   * @param string $query
+   * @param array $options
    * @return QueryBuilder
    * @throws InvalidArgumentException
    */
-  public function search($field, string $keyword): QueryBuilder
+  public function search($fields, string $query, array $options = []): QueryBuilder
   {
-    if (empty($field)) {
+    if (empty($fields)) {
       throw new InvalidArgumentException('Cant perform search due to no field name was provided');
     }
-    if (!empty($keyword)) {
-      $this->searchKeyword = [
-        'field' => (array)$field,
-        'keyword' => $keyword
+    if (!empty($query)) {
+      $this->search = [
+        'fields' => (array)$fields,
+        'query' => $query
       ];
+      if(!empty($options)){
+        if(array_key_exists("minLength", $options) && is_int($options["minLength"]) && $options["minLength"] > 0){
+          $this->searchOptions["minLength"] = $options["minLength"];
+        }
+        if(array_key_exists("mode", $options) && is_string($options["mode"])){
+          $searchMode = strtolower(trim($options["mode"]));
+          if(in_array($searchMode, ["and", "or"])){
+            $this->searchOptions["mode"] = $searchMode;
+          }
+        }
+        if(array_key_exists("scoreKey", $options) && (is_string($options["scoreKey"]) || is_null($options["scoreKey"]))){
+          $this->searchOptions["scoreKey"] = $options["scoreKey"];
+        }
+      }
     }
     return $this;
   }

--- a/src/Store.php
+++ b/src/Store.php
@@ -622,7 +622,20 @@ class Store
     return (!file_exists($filePath) || true === @unlink($filePath));
   }
 
-  public function search(array $fields, string $query, array $orderBy = null, int $limit = null, int $offset = null){
+  /**
+   * Do a fulltext like search against one or multiple fields.
+   * @param array $fields
+   * @param string $query
+   * @param array|null $orderBy
+   * @param int|null $limit
+   * @param int|null $offset
+   * @return array
+   * @throws IOException
+   * @throws InvalidArgumentException
+   * @throws InvalidPropertyAccessException
+   */
+  public function search(array $fields, string $query, array $orderBy = null, int $limit = null, int $offset = null): array
+  {
 
     $qb = $this->createQueryBuilder();
 


### PR DESCRIPTION
# Store wide configuration

```php
// default configuration
$configuration = [
  "search" => [
    "min_length" => 2,
    "mode" => "or",
    "score_key" => "searchScore"
  ]
];

$store = new Store("comments", $dataDir, $configuration);
```

## min_length
This configuration has to be an integer > 0. It defines the minimum word length of the query. If min_length is for example 2 and the user wants to search through the store with a query that is "I love William cool", the word "I" will be ignored because it is < 2. That means with the configuration of 2 all words >= 2 are considered when searching.

## mode
Two modes are supported: 
- `and`
- `or`

### and
With this mode a field has to contain all words in the correct order to be considered as a search hit.
Example:
Our query is "Where School" and we have two values to check agains:
1. "**Where** do you think is the best **school**?"
    - Search hit
2. "**School** is cool, but **where** is the best one?"
    - No search hit 

### or
With this mode a field has to contain one of the words searched.
Example:
Our query is "Where School" and we have three values to check agains:
1. "**Where** do you think is the best **school**?"
    - Two search hits 
2. "**School** is cool, but **where** is the best one?"
    - Two search hits 
3. "Why everybody love **School**"
    - One search hit 

## score_key
If this configuration is `null` no field containing the score will be applied to the documents.
Otherwise a new field with the specified field name will be applied to every document, which will contain the search score and can be used to for example sort the documents.

# New search method
The Store class now has a new method.
```php
function search(array $fields, string $query, array $orderBy = null, int $limit = null, int $offset = null): array
```

# Configuration of search on a query by query base

The search method of QueryBuilder got a new $options parameter.

```php
function search(string|array $fields, string $query, array $options = []): QueryBuilder
```

The $options parameter allows configuring the search on a query by query base with the following configuration options:

```php
[
  "minLength" => 2, // has to be an integer > 0
  "mode" => "or", // can be "and" or "or"
  "scoreKey" => "searchScore" // has to be a string or null
]
```

# Important!

With this new algorithm the **amount of fields that can be searched through at the same time is capped to 100**!

# Field ranking

When searching through documents the user specifies which fields to search.
For example:
```php
$store->search([ "title", "content", "description" ], $query);
```

The order of the fields is important!
In the above example search hits in a `title` field have much more weight than search hits in a `content` field which have much more weight than search hits in a `description` field.

Hypothetical example (score numbers are not real but represent what is meant):
We have multiple documents.
1. Document has 1 hit in `title`
    -  1000
2. Document has 1 hit in `title` and 2 hits in `content`
    - 1200 
3. Document has 23 hits in `content`
    - 600 
4. Document has 60 hits in `description`
    - 300

# Full code examples

```php

$articleStore = new Store("articles", __DIR__."/database");
$commentStore = new Store("articles", __DIR__."/database");

$query = "SleekDB"

// Example 1
$result = $articleStore->createQueryBuilder()
  ->search(["title", "content"], $query)
  ->orderBy(["searchScore" => "desc"])
  ->except(["searchScore"]) // remove searchScore from result after using it to sort
  ->getQuery()
  ->fetch()

// Example 2
$result = $articleStore->createQueryBuilder()
  ->join(function($article) use ($commentStore) {
    return $commentStore->findBy(["articleId", "=", $article["_id"]])
  }, "comments")
  ->search(["title", "content", "comments.title", "comments.content"], $query)
  ->orderBy(["searchScore" => "desc"])
  ->except(["searchScore"]) // remove searchScore from result after using it to sort
  ->getQuery()
  ->fetch()
```