### PR TITLE
Fixed delete return options. Added search algorithms. Small optimizations.

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace SleekDB;
 
+use Closure;
 use SleekDB\Exceptions\InvalidArgumentException;
 
 class QueryBuilder
@@ -26,7 +27,8 @@ class QueryBuilder
   protected $searchOptions = [
     "minLength" => 2,
     "scoreKey" => "searchScore",
-    "mode" => "or"
+    "mode" => "or",
+    "algorithm" => Query::SEARCH_ALGORITHM["hits"]
   ];
 
   protected $fieldsToSelect = [];
@@ -71,7 +73,6 @@ class QueryBuilder
    * Select specific fields
    * @param string[] $fieldNames
    * @return QueryBuilder
-   * @throws InvalidArgumentException
    */
   public function select(array $fieldNames): QueryBuilder
   {
@@ -322,17 +323,20 @@ class QueryBuilder
         if(array_key_exists("scoreKey", $options) && (is_string($options["scoreKey"]) || is_null($options["scoreKey"]))){
           $this->searchOptions["scoreKey"] = $options["scoreKey"];
         }
+        if(array_key_exists("algorithm", $options) && in_array($options["algorithm"], Query::SEARCH_ALGORITHM, true)){
+          $this->searchOptions["algorithm"] = $options["algorithm"];
+        }
       }
     }
     return $this;
   }
 
   /**
-   * @param \Closure $joinFunction
+   * @param Closure $joinFunction
    * @param string $dataPropertyName
    * @return QueryBuilder
    */
-  public function join(\Closure $joinFunction, string $dataPropertyName): QueryBuilder
+  public function join(Closure $joinFunction, string $dataPropertyName): QueryBuilder
   {
     $this->listOfJoins[] = [
       'dataPropertyName' => $dataPropertyName,
@@ -408,7 +412,7 @@ class QueryBuilder
     $conditionsArray = $this->_getConditionProperties();
 
     foreach ($conditionsArray as $propertyName => $propertyValue){
-      if(!in_array($propertyName, $this->propertiesNotUsedForCacheToken)){
+      if(!in_array($propertyName, $this->propertiesNotUsedForCacheToken, true)){
         $properties[$propertyName] = $propertyValue;
       }
     }
@@ -425,7 +429,7 @@ class QueryBuilder
     $properties = [];
 
     foreach ($allProperties as $propertyName => $propertyValue){
-      if(!in_array($propertyName, $this->propertiesNotUsedInConditionsArray)){
+      if(!in_array($propertyName, $this->propertiesNotUsedInConditionsArray, true)){
         $properties[$propertyName] = $propertyValue;
       }
     }

--- a/src/Traits/IoHelperTrait.php
+++ b/src/Traits/IoHelperTrait.php
@@ -2,6 +2,7 @@
 
 namespace SleekDB\Traits;
 
+use Closure;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SleekDB\Exceptions\IOException;
@@ -114,11 +115,13 @@ trait IoHelperTrait {
 
   /**
    * @param string $filePath
-   * @param \Closure $updateContentFunction
-   * @return mixed
+   * @param Closure $updateContentFunction
+   * @return string
    * @throws IOException
+   * @throws JsonException
    */
-  private static function updateFileContent(string $filePath, \Closure $updateContentFunction){
+  private static function updateFileContent(string $filePath, Closure $updateContentFunction): string
+  {
     self::_checkRead($filePath);
     self::_checkWrite($filePath);
 


### PR DESCRIPTION
#37 
# 4 search algorithms

The available search algorithms can be found as a constant in the Query class.

## hits

This is the default algorithm.
The score is based on the amount of search hits.

## hits_prioritize

The score is based on the amount of hits but if two or more documents have the same amount of hits the order of the given fields is taken into consideration.

## prioritize

The order of the fields are a big part of the score.  Example:

We search using the following array containing field names.

```php
[ "title", "subtitle", "content" ]
```

If we now have three documents with the following amounts of hits in the different fields and you see their score you understand what this algorithm does (The scores are not real, their purposes are just for demonstration):

1. One hit in title
    - 1000
2. 30 hits in subtitle
    - 600 
3. 70 hits in content
    - 300 

## prioritize_position

Does the same as the "prioritize" method but if two documents have the same amount of hits in the same fields the document with the lower hit position will have a higher score.