### PR TITLE
Feature/support string ids

### DIFF
--- a/src/Store.php
+++ b/src/Store.php
@@ -326,8 +326,6 @@ class Store
 //    }
 
     if(!array_key_exists($primaryKey, $data)) {
-//        $documentString = var_export($document, true);
-//        throw new InvalidArgumentException("Documents have to have the primary key \"$primaryKey\". Got data: $documentString");
       $data[$primaryKey] = $this->increaseCounterAndGetNextId();
     } else {
       $data[$primaryKey] = $this->checkAndStripId($data[$primaryKey]);
@@ -375,13 +373,13 @@ class Store
       if(!is_array($document)) {
         throw new InvalidArgumentException('Documents have to be an arrays.');
       }
-      if(!array_key_exists($primaryKey, $document)) {
-//        $documentString = var_export($document, true);
-//        throw new InvalidArgumentException("Documents have to have the primary key \"$primaryKey\". Got data: $documentString");
-        $document[$primaryKey] = $this->increaseCounterAndGetNextId();
-      } else {
-        $document[$primaryKey] = $this->checkAndStripId($document[$primaryKey]);
-        if($autoGenerateIdOnInsert && $this->findById($document[$primaryKey]) === null){
+
+      $pKey = $document[$primaryKey] ?? null;
+
+      // No key => create new key
+      if(!$pKey) {
+        // throw new InvalidArgumentException('No primary key');
+        if($autoGenerateIdOnInsert){
           $document[$primaryKey] = $this->increaseCounterAndGetNextId();
         }
       }
@@ -811,8 +809,7 @@ class Store
     // Prepare storable data
     $storableJSON = @json_encode($storeData);
     if ($storableJSON === false) {
-      throw new JsonException('Unable to encode the data array, 
-        please provide a valid PHP associative array');
+      throw new JsonException('Unable to encode the data array, please provide a valid PHP associative array');
     }
     // Define the store path
     $filePath = $this->getDataPath()."$id.json";
@@ -828,24 +825,11 @@ class Store
    * @throws IOException
    * @throws JsonException
    */
-  private function increaseCounterAndGetNextId(): int
+  private function increaseCounterAndGetNextId(): string
   {
-    $counterPath = $this->getStorePath() . '_cnt.sdb';
-
-    if (!file_exists($counterPath)) {
-      throw new IOException("File $counterPath does not exist.");
-    }
-
-    $dataPath = $this->getDataPath();
-
-    return (int) IoHelper::updateFileContent($counterPath, function ($counter) use ($dataPath){
-      $newCounter = ((int) $counter) + 1;
-
-      while(file_exists($dataPath."$newCounter.json") === true){
-        $newCounter++;
-      }
-      return (string)$newCounter;
-    });
+   
+    $id = uniqid(null, TRUE);
+    return str_replace(".", "", $id);
   }
 
 
@@ -854,7 +838,7 @@ class Store
    * @return int
    * @throws InvalidArgumentException
    */
-  private function checkAndStripId($id): int
+  private function checkAndStripId($id = ''): string
   {
     if(!is_string($id) && !is_int($id)){
       throw new InvalidArgumentException("The id of the document has to be an integer or string");
@@ -864,11 +848,8 @@ class Store
       $id = IoHelper::secureStringForFileAccess($id);
     }
 
-    if(!is_numeric($id)){
-      throw new InvalidArgumentException("The id of the document has to be numeric");
-    }
 
-    return (int) $id;
+    return (string) $id;
   }
 
   /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -21,7 +21,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->where(["_id", "=", 1])->getQuery()->fetch();
+    $users = $userQueryBuilder->where(["name", "=", "Tundra"])->getQuery()->fetch();
 
     self::assertCount(1, $users);
   }
@@ -30,7 +30,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->where(["_id", "=", 1])->orWhere(["_id", "=", 2])->getQuery()->fetch();
+    $users = $userQueryBuilder->where(["name", "=", "Tundra"])->orWhere(["name","=","LR3"])->getQuery()->fetch();
 
     self::assertCount(2, $users);
   }
@@ -39,7 +39,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->where(["_id", "=", 1])->orWhere([["_id", "=", 2], ["_id", "=", 3]])->getQuery()->fetch();
+    $users = $userQueryBuilder->where(["name", "=", "Tundra"])->orWhere([["name","=","LR3"], ["name","=","Cougar"]])->getQuery()->fetch();
 
     self::assertCount(1, $users);
   }
@@ -48,7 +48,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->where(["_id", "=", 1])->where(["_id", "=", 2])->getQuery()->fetch();
+    $users = $userQueryBuilder->where(["name", "=", "Tundra"])->where(["name","=","LR3"])->getQuery()->fetch();
 
     self::assertCount(0, $users);
   }
@@ -57,7 +57,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->except(["_id", "name"])->where(["_id", "=", 1])->getQuery()->fetch();
+    $users = $userQueryBuilder->except(["_id", "name"])->where(["name", "=", "Tundra"])->getQuery()->fetch();
 
     foreach ($users as $user){
       self::assertArrayNotHasKey("_id", $user);
@@ -69,7 +69,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->select(["_id", "price"])->where(["_id", "=", 1])->getQuery()->fetch();
+    $users = $userQueryBuilder->select(["_id", "price"])->where(["name", "=", "Tundra"])->getQuery()->fetch();
 
     foreach ($users as $user){
       self::assertArrayHasKey("_id", $user);
@@ -82,7 +82,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->where(["_id","in",[1,2]])->getQuery()->fetch();
+    $users = $userQueryBuilder->where(["name","in",["Tundra","LR3"]])->getQuery()->fetch();
 
     self::assertCount(2, $users);
   }
@@ -91,7 +91,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $users = $userQueryBuilder->where(["_id", "not in", [1,2]])->getQuery()->fetch();
+    $users = $userQueryBuilder->where(["name", "not in", ["Tundra","LR3"]])->getQuery()->fetch();
 
     self::assertCount(count(self::DATABASE_DATA["users"]) - 2, $users);
   }
@@ -151,13 +151,13 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $userExists = $userQueryBuilder->where(["_id", "=", 1])->getQuery()->exists();
+    $userExists = $userQueryBuilder->where(["name", "=", "Tundra"])->getQuery()->exists();
 
     self::assertTrue($userExists);
 
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $userExists = $userQueryBuilder->where(["_id", "=", 2])->where(["_id", "=", 1])->getQuery()->exists();
+    $userExists = $userQueryBuilder->where(["name","=","LR3"])->where(["name", "=", "Tundra"])->getQuery()->exists();
 
     self::assertFalse($userExists);
   }
@@ -166,7 +166,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $query = $userQueryBuilder->where(["_id", "=", 1])->useCache()->getQuery();
+    $query = $userQueryBuilder->where(["name", "=", "Tundra"])->useCache()->getQuery();
 
     $userCache = $query->getCache();
 
@@ -181,7 +181,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $query = $userQueryBuilder->where(["_id", "=", 1])->useCache(null)->getQuery();
+    $query = $userQueryBuilder->where(["name", "=", "Tundra"])->useCache(null)->getQuery();
 
     $userCache = $query->getCache();
 
@@ -196,7 +196,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $query = $userQueryBuilder->where(["_id", "=", 1])->useCache(0)->getQuery();
+    $query = $userQueryBuilder->where(["name", "=", "Tundra"])->useCache(0)->getQuery();
 
     $userCache = $query->getCache();
 
@@ -215,7 +215,7 @@ final class QueryTest extends SleekDBTestCase
     $userStore = $this->stores["users"];
     $userQueryBuilder = $userStore->createQueryBuilder();
 
-    $query = $userQueryBuilder->where(["_id", "=", 1])->useCache(1)->getQuery();
+    $query = $userQueryBuilder->where(["name", "=", "Tundra"])->useCache(1)->getQuery();
 
     $userCache = $query->getCache();
 


### PR DESCRIPTION
Great library, yet I wanted to port some data from a mongodb database. This blocked me from using SleekDb as mongodb uses a string as primary key. It would nice to see this supported in SleekDb or maybe as an options. Here I created a minimal setup for it to use a string as key. Most likely it should be behind some flag to be backward compatible. Hope you can have a look and bring in support for string primary keys. Great work by the way.