### PR TITLE
Updated default value of timeout to boolean false

### DIFF
--- a/src/Store.php
+++ b/src/Store.php
@@ -40,7 +40,7 @@ class Store
   protected $useCache = true;
   protected $defaultCacheLifetime;
   protected $primaryKey = "_id";
-  protected $timeout = 120;
+  protected $timeout = false;
   protected $searchOptions = [
     "minLength" => 2,
     "scoreKey" => "searchScore",


### PR DESCRIPTION
A small change that will set the default value of timeout to `false`. It will also hide the PHP deprecation warning.

BEFPRE | AFTER
![sleekdb-console](https://user-images.githubusercontent.com/5412730/151885992-feae82c1-3835-41f9-b45f-845f5f3f298c.JPG)
